### PR TITLE
status_id should default to 1000

### DIFF
--- a/lib/NephologyServer/Install.pm
+++ b/lib/NephologyServer/Install.pm
@@ -179,7 +179,7 @@ sub discovery {
 		mtime => time,
 		asset_tag => '',
 		caste_id => '0',
-		status_id => '1',
+		status_id => '1000',
 		domain => '',
 		primary_ip => '',
 		hostname => '',


### PR DESCRIPTION
In discovery, the vm has already booted into the installer. Next time the machine boots we should be local booting.
