### PR TITLE
discovery: check if node exists before creating new one

### DIFF
--- a/lib/NephologyServer/Install.pm
+++ b/lib/NephologyServer/Install.pm
@@ -167,6 +167,15 @@ sub discovery {
                 );
 	}
 
+    my $Node = NephologyServer::Validate::validate($self,$boot_mac);
+
+    if ($Node) {
+        return $self->render(
+                        text => "$boot_mac already discovered",
+                        status => 409
+               );
+    }
+
 	my $json = $self->req->body;
 	my $ohai = decode_json($json);
 

--- a/templates/os/trusty.sh.txt.ep
+++ b/templates/os/trusty.sh.txt.ep
@@ -60,6 +60,7 @@ echo "Done!"
 echo "Installing sources.list"
 cat > /target/etc/apt/sources.list <<EOF
 deb http://<%= $mirror_addr %>/ubuntu trusty main universe restricted
+deb http://<%= $mirror_addr %>/ubuntu trusty-security main universe restricted
 EOF
 
 # temporary, install.sh removes


### PR DESCRIPTION
Do not create a node if one already exists when discovering new nodes.
